### PR TITLE
Fixed typo in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ if [ ! -d $BUILD ]
 	then mkdir $BUILD
 fi
 
-# Compile the Lanague files
+# Compile the Language files
 cd $DIR/language
 ./build_lang.sh
 cd $DIR


### PR DESCRIPTION
Hi.

There was a typo in build.sh script file. 

This has been amended.

Thank you.
